### PR TITLE
removed random scissorTest & duplicate ImguiIO get

### DIFF
--- a/rlImGui/rlImGui.cpp
+++ b/rlImGui/rlImGui.cpp
@@ -99,7 +99,6 @@ static void rlImGuiNewFrame()
             else
             {
                 ShowCursor();
-                ImGuiIO& io = ImGui::GetIO();
 
                 if (!(io.ConfigFlags & ImGuiConfigFlags_NoMouseCursorChange))
                 {
@@ -338,8 +337,6 @@ void InitRLGLImGui()
 void FinishRLGLImguSetup()
 {
     SetupMouseCursors();
-
-    rlEnableScissorTest();
 
     ImGuiIO& io = ImGui::GetIO();
     io.BackendPlatformName = "imgui_impl_raylib";


### PR DESCRIPTION
the scissorTest I removes seems to have no purpose, it also messes with everything that is done before its disabled again

saw randomly that there was a IO ref created where one already is available, so I removed it