### PR TITLE
rlImGui fix Crash on empty RenderTriangle Calls

### DIFF
--- a/rlImGui/rlImGui.cpp
+++ b/rlImGui/rlImGui.cpp
@@ -274,6 +274,9 @@ static void rlImGuiTriangleVert(const ImDrawVert& idx_vert)
 
 static void rlImGuiRenderTriangles(unsigned int count, int indexStart, const ImVector<ImDrawIdx>& indexBuffer, const ImVector<ImDrawVert>& vertBuffer, void* texturePtr)
 {
+    if (count == 0)
+        return;
+
     Texture* texture = (Texture*)texturePtr;
 
     unsigned int textureId = (texture == nullptr) ? 0 : texture->id;


### PR DESCRIPTION
on some occasions I found that calls to this function can contain a count of 0, which causes this function to crash