### PR TITLE
Fix memory leak and crash on exit

### DIFF
--- a/rlImGui/rlImGui.cpp
+++ b/rlImGui/rlImGui.cpp
@@ -68,6 +68,7 @@ void AddRLImGuiIconFonts(float size, bool awesome)
         ImFontConfig icons_config;
         icons_config.MergeMode = true;
         icons_config.PixelSnapH = true;
+        icons_config.FontDataOwnedByAtlas = false;
         io.Fonts->AddFontFromMemoryTTF(forkawesome_webfont_ttf, forkawesome_webfont_ttf_len, size, &icons_config, icons_ranges);
     }
 }

--- a/rlImGui/rlImGui.cpp
+++ b/rlImGui/rlImGui.cpp
@@ -58,6 +58,7 @@ void AddRLImGuiIconFonts(float size, bool awesome)
         ImFontConfig icons_config;
         icons_config.MergeMode = true;
         icons_config.PixelSnapH = true;
+        icons_config.FontDataOwnedByAtlas = false;
         io.Fonts->AddFontFromMemoryTTF(FA5Free_Solid_900_otf, FA5Free_Solid_900_otf_len, size, &icons_config, icons_ranges);
     }
     else
@@ -459,6 +460,8 @@ void ShutdownRLImGui()
 
     UnloadTexture(FontTexture);
     LoadedTextures.clear();
+
+    ImGui::DestroyContext();
 }
 
 void RLImGuiImage(const Texture *image)


### PR DESCRIPTION
FontDataOwnedByAtlas has to be set to false to void imgui trying to free the static font data

ImGui::DestroyContext() is never called inside rlImGui, but ImGui::CreateContext() is, so I figured it should be called aswell